### PR TITLE
fix page number display in navigation bar within search results footer

### DIFF
--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -623,27 +623,11 @@ export class FooterPanel extends BaseFooterPanel {
     }
 
     setPlacemarkerLabel(): void {
-
         const displaying: string = this.content.displaying;
         const index: number = this.extension.helper.canvasIndex;
+        const prefix: string = this.isPageModeEnabled ? this.content.page : this.content.image;
 
-        if (this.isPageModeEnabled()) {
-            const canvas: Manifesto.ICanvas = this.extension.helper.getCanvasByIndex(index);
-            let label: string | null = Manifesto.TranslationCollection.getValue(canvas.getLabel());
-
-            if (!label) {
-                label = this.content.defaultLabel;
-            }
-
-            const lastCanvasOrderLabel: string | null = this.extension.helper.getLastCanvasLabel(true);
-
-            if (lastCanvasOrderLabel) {
-                this.$pagePositionLabel.html(String.format(displaying, this.content.page, UVUtils.sanitize(<string>label), UVUtils.sanitize(<string>lastCanvasOrderLabel)));
-            }
-
-        } else {
-            this.$pagePositionLabel.html(String.format(displaying, this.content.image, index + 1, this.extension.helper.getTotalCanvases()));
-        }
+        this.$pagePositionLabel.html(String.format(displaying, prefix, index + 1, this.extension.helper.getTotalCanvases()));
     }
 
     isPageModeEnabled(): boolean {


### PR DESCRIPTION
This PR addresses https://github.com/sul-dlss/content_search/issues/6 in DLSS content_search. The changes eliminate logic that used to handle paged and unpaged objects differently. This seems reasonable because of the use of the construct "image/page [n] _of_ [m]" as a design choice. Canvas labels often don't describe order in any way [[cit.](http://iiif.io/api/presentation/2.1/#label)], leading to examples such as "page Homily of March of Appendices", which doesn't make much sense.

The Presentation API doesn't provide a way to have a "logical page number" and "digital page (IIIF "Canvas") number or "sequence index" apart from labels, which can have any content whatsoever, so I'm not sure what a better design choice might be here. In the meantime, this uses data that is always available (the number of canvases, regardless of viewingHint) to give an idea of the relative position of the currently focuses canvas in the sequence. I think the spec lacks the data to do better than that for now.    

